### PR TITLE
Fix Docker build with pnpm@latest

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,11 +56,5 @@
         "orval": "^8.5.1",
         "typescript": "~5.9.3",
         "vite": "^7.3.3"
-    },
-    "pnpm": {
-        "overrides": {
-            "brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
-            "socket.io-parser@>=4.0.0 <4.2.6": ">=4.2.6"
-        }
     }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+overrides:
+  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
+  socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'


### PR DESCRIPTION
## Summary

The Docker build (`pnpm@latest` via corepack) fails with `pnpm install --frozen-lockfile` because of two breaking changes between pnpm 10 (used by GitHub Actions CI) and pnpm 11 (currently `latest`):

1. **`pnpm.overrides` in `package.json` is no longer read** — pnpm 11 ignores the field and the lockfile's `overrides:` no longer matches the active config, producing `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
2. **Ignored dependency build scripts are a hard error** — pnpm 11 errors with `ERR_PNPM_IGNORED_BUILDS` for `esbuild`, where pnpm 10 only printed a warning.

CI never caught either because `pnpm/action-setup@v4` pins pnpm to version 10.

## Changes

- Move overrides from `frontend/package.json` (`pnpm.overrides`) to a new `frontend/pnpm-workspace.yaml` — the new home pnpm has moved these settings to.
- Update `frontend/Dockerfile` to also `COPY pnpm-workspace.yaml` so the install can read it.
- Pass `--ignore-scripts` to `pnpm install` in the Dockerfile to explicitly skip dependency lifecycle scripts (esbuild's per-platform binaries are already provided by its `@esbuild/*` sub-packages, so its postinstall is not required — pnpm 10 was already skipping it with a warning, this just makes it explicit).

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally with pnpm 10
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `docker compose build frontend-build` succeeds on a Pi running pnpm 11.1.3 via `corepack prepare pnpm@latest --activate` (vite build completes, image built)